### PR TITLE
fix(agent): .env loading 에러 수정

### DIFF
--- a/agent/dev.py
+++ b/agent/dev.py
@@ -47,6 +47,12 @@ def main():
 
     settings = get_settings()
 
+    ## Print all settings for verification
+    # model_dic = settings.model_dump()   
+    # for group in model_dic.keys():
+    #     for key, value in model_dic[group].items():
+    #         print(f"{key}: {value}")
+    
     # Override settings for development
     settings.api.reload = True
     settings.development.debug = True

--- a/agent/src/config.py
+++ b/agent/src/config.py
@@ -50,7 +50,6 @@ class KubernetesSettings(BaseSettings):
     class Config:
         env_prefix = "K8S_"
 
-
 class APISettings(BaseSettings):
     """API server configuration."""
 
@@ -126,7 +125,7 @@ class Settings(BaseSettings):
         env_file = ".env"
         env_file_encoding = "utf-8"
         case_sensitive = False
-
+        extra = "ignore"
 
 # Global settings instance
 _settings: Settings | None = None


### PR DESCRIPTION
.env 값들을 BaseSettings 통해 불러올 때, 서브 클래스들 중 env_prefix 존재 여부에 따라 불러오는 방식이 달라 매핑이 잘 안되고 있었던 것 같습니다. 

최상위 클래스부분 수정했고, 잘 불러오는지 확인을 위한 dump 코드도 추가해두었습니다